### PR TITLE
Fix CreditCardForm#isCreditCardValid().

### DIFF
--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/CreditCardText.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/CreditCardText.java
@@ -45,8 +45,8 @@ public class CreditCardText extends CreditEntryFieldBase {
 			CardType type = CreditCardUtil.findCardType(number);
 
 			if (type.equals(CardType.INVALID)) {
-				delegate.onBadInput(this);
 				setValid(false);
+				delegate.onBadInput(this);
 				return;
 			}
 
@@ -65,11 +65,11 @@ public class CreditCardText extends CreditEntryFieldBase {
 
 			if (formatted.length() >= CreditCardUtil.lengthOfFormattedStringForType(type)) {
 				if (CreditCardUtil.isValidNumber(formatted)) {
-					delegate.onCreditCardNumberValid();
 					setValid(true);
+					delegate.onCreditCardNumberValid();
 				} else {
-					delegate.onBadInput(this);
 					setValid(false);
+					delegate.onBadInput(this);
 				}
 			}
 

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/ExpDateText.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/ExpDateText.java
@@ -48,11 +48,11 @@ public class ExpDateText extends CreditEntryFieldBase {
 			this.addTextChangedListener(this);
 			
 			if(formatted.length() == 5) {
-				delegate.onExpirationDateValid();
 				setValid(true);
+				delegate.onExpirationDateValid();
 			} else if(formatted.length() < updatedString.length()) {
-				delegate.onBadInput(this);
 				setValid(false);
+				delegate.onBadInput(this);
 			}
 		}
 	}

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/SecurityCodeText.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/SecurityCodeText.java
@@ -50,8 +50,8 @@ public class SecurityCodeText extends CreditEntryFieldBase {
 			String number = s.toString();
 
 			if (number.length() == length) {
-				delegate.onSecurityCodeValid();
 				setValid(true);
+				delegate.onSecurityCodeValid();
 			} else {
 				setValid(false);
 			}

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/ZipCodeText.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/ZipCodeText.java
@@ -38,8 +38,8 @@ public class ZipCodeText extends CreditEntryFieldBase {
 	public void textChanged(CharSequence s, int start, int before, int end) {
 		String zipCode = s.toString();
 		if (zipCode.length() == 5) {
-			delegate.onZipCodeValid();
 			setValid(true);
+			delegate.onZipCodeValid();
 		} else {
 			setValid(false);
 		}


### PR DESCRIPTION
CreditCardForm#isCreditCardValid() always returns if called from the CardValidCallback#cardValid(). This is because the base credit cards fields are not calling `setValid()` until AFTER they call the delegate's update methods. This patch just reverses the order of the delegate and `setValid()` calls.
