### PR TITLE
Use text colors from application theme

### DIFF
--- a/CreditCardEntry/res/values/attrs.xml
+++ b/CreditCardEntry/res/values/attrs.xml
@@ -12,5 +12,6 @@
         <attr name="cursor_color"       format="color"/>
         <attr name="card_number_hint"   format="string"/>
         <attr name="input_background"   format="reference"/>
+        <attr name="default_text_colors" format="boolean"/>
     </declare-styleable>
 </resources>

--- a/CreditCardEntry/res/values/ids.xml
+++ b/CreditCardEntry/res/values/ids.xml
@@ -8,4 +8,5 @@
     <item name="cc_ccv" type="id">4444</item>
     <item name="cc_zip" type="id">5555</item>
     <item name="text_helper" type="id">2000</item>
+    <item name="null_color" type="color">234234</item>
 </resources>

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/CreditEntryFieldBase.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/fields/CreditEntryFieldBase.java
@@ -82,9 +82,13 @@ public abstract class CreditEntryFieldBase extends EditText implements
 		}
 
 		TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.CreditCardForm);
-		setTextColor(typedArray.getColor(R.styleable.CreditCardForm_text_color, Color.BLACK));
-		setHintTextColor(typedArray.getColor(R.styleable.CreditCardForm_hint_text_color, Color.LTGRAY));
-		setCursorDrawableColor(typedArray.getColor(R.styleable.CreditCardForm_cursor_color, Color.BLACK));
+		// If CreditCardForm_default_text_colors is true, we will not set any text or cursor colors
+		// and just use the defaults provided by the system / theme.
+		if (!typedArray.getBoolean(R.styleable.CreditCardForm_default_text_colors, false)) {
+			setTextColor(typedArray.getColor(R.styleable.CreditCardForm_text_color, Color.BLACK));
+			setHintTextColor(typedArray.getColor(R.styleable.CreditCardForm_hint_text_color, Color.LTGRAY));
+			setCursorDrawableColor(typedArray.getColor(R.styleable.CreditCardForm_cursor_color, Color.BLACK));
+		}
 		typedArray.recycle();
 	}
 

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/internal/CreditCardEntry.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/internal/CreditCardEntry.java
@@ -57,7 +57,8 @@ public class CreditCardEntry extends HorizontalScrollView implements
         OnTouchListener, OnGestureListener, CreditCardFieldDelegate {
 
     private final Context context;
-    private final int textColor;
+    // null textColor means we want to use the system default color instead of providing our own.
+    private final Integer textColor;
 
     private ImageView cardImage;
     private ImageView backCardImage;
@@ -86,7 +87,11 @@ public class CreditCardEntry extends HorizontalScrollView implements
         this.context = context;
 
         TypedArray typedArray = context.getTheme().obtainStyledAttributes(attrs, R.styleable.CreditCardForm, 0, 0);
-        textColor = typedArray.getColor(R.styleable.CreditCardForm_text_color, Color.BLACK);
+        if (!typedArray.getBoolean(R.styleable.CreditCardForm_default_text_colors, false)) {
+            textColor = typedArray.getColor(R.styleable.CreditCardForm_text_color, Color.BLACK);
+        } else {
+            textColor = null;
+        }
         typedArray.recycle();
 
         WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
@@ -123,7 +128,9 @@ public class CreditCardEntry extends HorizontalScrollView implements
 
         textFourDigits = new TextView(context);
         textFourDigits.setTextSize(20);
-        textFourDigits.setTextColor(textColor);
+        if (textColor != null) {
+            textFourDigits.setTextColor(textColor);
+        }
         container.addView(textFourDigits);
 
         expDateText = new ExpDateText(context, attrs);

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/internal/CreditCardEntry.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/internal/CreditCardEntry.java
@@ -276,7 +276,9 @@ public class CreditCardEntry extends HorizontalScrollView implements
         handler.postDelayed(new Runnable() {
             @Override
             public void run() {
-                field.setTextColor(textColor);
+                if (textColor != null) {
+                    field.setTextColor(textColor);
+                }
             }
         }, 1000);
     }

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/library/CreditCardForm.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/library/CreditCardForm.java
@@ -31,6 +31,7 @@ public class CreditCardForm extends RelativeLayout {
 	private boolean includeHelper;
 	private int textHelperColor;
 	private Drawable inputBackground;
+	private boolean useDefaultColors;
 	private String cardNumberHint = "1234 5678 9012 3456";
 
 	public CreditCardForm(Context context) {
@@ -65,6 +66,7 @@ public class CreditCardForm extends RelativeLayout {
 					this.includeHelper = typedArray.getBoolean(R.styleable.CreditCardForm_include_helper, true);
 					this.textHelperColor = typedArray.getColor(R.styleable.CreditCardForm_helper_text_color, getResources().getColor(R.color.text_helper_color));
 					this.inputBackground = typedArray.getDrawable(R.styleable.CreditCardForm_input_background);
+					this.useDefaultColors = typedArray.getBoolean(R.styleable.CreditCardForm_default_text_colors, false);
 				} finally {
 					if (typedArray != null) typedArray.recycle();
 				}
@@ -145,7 +147,9 @@ public class CreditCardForm extends RelativeLayout {
 			TextView textHelp = new TextView(context);
             textHelp.setId(R.id.text_helper);
 			textHelp.setText(getResources().getString(R.string.CreditCardNumberHelp));
-			textHelp.setTextColor(this.textHelperColor);
+			if (useDefaultColors) {
+				textHelp.setTextColor(this.textHelperColor);
+			}
 			layoutParams = new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
 			layoutParams.addRule(RelativeLayout.BELOW, layout.getId());
 			layoutParams.addRule(RelativeLayout.CENTER_HORIZONTAL);

--- a/README.md
+++ b/README.md
@@ -60,11 +60,15 @@ XML
 
 ```
 
- * `app:helper_text_color` - change the text color of the hints that appear below the widget by default.
  * `app:text_color` - change the input field's text color (`Color.BLACK` by default).
  * `app:hint_text_color` - change the input field's hint text color (`Color.LTGRAY` by default).
  * `app:cursor_color` - change the input field's cursor color (`Color.BLACK` by default).
+ * `app:default_text_colors` - If true, use text colors provided by the app's theme instead of the
+   values provided by `app:text_color`,`app:hint_text_color`, and `app:cursor_color`. This overrides
+   the values for those three text colors and causes the text inputs to use the colors provided by
+   the application's theme.
  * `app:include_helper` - boolean to show/hide the helper text under the widget (`true` by default (i.e. helper is shown))
+ * `app:helper_text_color` - change the text color of the hints that appear below the widget by default.
  * `app:include_zip` - boolean to show/hide the zip code in the form (`true` by default (i.e. zip is shown))
  * `app:include_exp` - boolean to show/hide the exp in the form (`true` by default (i.e. exp is shown))
  * `app:include_security` - boolean to show/hide the security code in the form (`true` by default (i.e. security is shown))


### PR DESCRIPTION
Add the new attribute 'default_text_colors'. When true, the cursor color, text color, and text hint colors come from the application Theme.

This is a possible solution to https://github.com/dbachelder/CreditCardEntry/issues/25
