### PR TITLE
Added property to disable default animation on input error

### DIFF
--- a/CreditCardEntry/res/values/attrs.xml
+++ b/CreditCardEntry/res/values/attrs.xml
@@ -13,5 +13,6 @@
         <attr name="card_number_hint"   format="string"/>
         <attr name="input_background"   format="reference"/>
         <attr name="default_text_colors" format="boolean"/>
+        <attr name="animate_on_error"   format="boolean"/>
     </declare-styleable>
 </resources>

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/internal/CreditCardEntry.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/internal/CreditCardEntry.java
@@ -77,6 +77,7 @@ public class CreditCardEntry extends HorizontalScrollView implements
 
     private boolean showingBack;
     private boolean scrolling = false;
+    private boolean animateOnError = true;
 
     private CardValidCallback onCardValidCallback;
 
@@ -268,10 +269,12 @@ public class CreditCardEntry extends HorizontalScrollView implements
 
     @Override
     public void onBadInput(final EditText field) {
-        Animation shake = AnimationUtils.loadAnimation(context, R.anim.shake);
-        field.startAnimation(shake);
-        field.setTextColor(Color.RED);
+        if (animateOnError) {
+            Animation shake = AnimationUtils.loadAnimation(context, R.anim.shake);
+            field.startAnimation(shake);
+        }
 
+        field.setTextColor(Color.RED);
         final Handler handler = new Handler();
         handler.postDelayed(new Runnable() {
             @Override
@@ -434,6 +437,10 @@ public class CreditCardEntry extends HorizontalScrollView implements
         if (delegate != null) {
             fieldToSet.setDelegate(delegate);
         }
+    }
+
+    public void setAnimateOnError(boolean animateOnError) {
+        this.animateOnError = animateOnError;
     }
 
     private CreditCardFieldDelegate getDelegate(final CreditCardFieldDelegate delegate) {

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/library/CreditCardForm.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/library/CreditCardForm.java
@@ -32,6 +32,7 @@ public class CreditCardForm extends RelativeLayout {
 	private int textHelperColor;
 	private Drawable inputBackground;
 	private boolean useDefaultColors;
+	private boolean animateOnError;
 	private String cardNumberHint = "1234 5678 9012 3456";
 
 	public CreditCardForm(Context context) {
@@ -67,6 +68,7 @@ public class CreditCardForm extends RelativeLayout {
 					this.textHelperColor = typedArray.getColor(R.styleable.CreditCardForm_helper_text_color, getResources().getColor(R.color.text_helper_color));
 					this.inputBackground = typedArray.getDrawable(R.styleable.CreditCardForm_input_background);
 					this.useDefaultColors = typedArray.getBoolean(R.styleable.CreditCardForm_default_text_colors, false);
+					this.animateOnError = typedArray.getBoolean(R.styleable.CreditCardForm_animate_on_error, true);
 				} finally {
 					if (typedArray != null) typedArray.recycle();
 				}
@@ -139,6 +141,8 @@ public class CreditCardForm extends RelativeLayout {
 		entry.setCardImageView(cardFrontImage);
 		entry.setBackCardImage(cardBackImage);
 		entry.setCardNumberHint(cardNumberHint);
+
+		entry.setAnimateOnError(animateOnError);
 
 		this.addView(layout);
 


### PR DESCRIPTION
I just added boolean xml attribute to disable the default 'shake' animation on the card validation error.
