### PR TITLE
Updated CreditCardEntry#focusOnField

### DIFF
--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/internal/CreditCardEntry.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/internal/CreditCardEntry.java
@@ -302,7 +302,7 @@ public class CreditCardEntry extends HorizontalScrollView implements
         field.requestFocus();
         if(!scrolling) {
             scrolling = true;
-            scrollToTarget(field instanceof CreditCardText ? 0 : field.getLeft(), new Runnable() {
+            scrollToTarget(field instanceof CreditCardText ? 0 : field.getRight(), new Runnable() {
                 @Override
                 public void run() {
                     scrolling = false;


### PR DESCRIPTION
Changed scrollToTarget() field.getLeft to field.getRight(). It gives me the desired behavior on my Note 5. I tested on various devices via emulator and it seems to have done the trick.

Resolves #38 
