### PR TITLE
Renaming name in CardType to prevent Enum Kotlin override conflicts

### DIFF
--- a/CreditCardEntry/build.gradle
+++ b/CreditCardEntry/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
     repositories {
         mavenCentral()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 apply plugin: 'com.android.library'
@@ -13,12 +14,11 @@ repositories {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 25
+        targetSdkVersion 28
     }
 
     sourceSets {
@@ -32,6 +32,7 @@ android {
             manifest.srcFile 'AndroidManifest.xml'
         }
     }
+    buildToolsVersion '27.0.3'
 }
 
 dependencies {

--- a/CreditCardEntry/src/com/devmarvel/creditcardentry/library/CardType.java
+++ b/CreditCardEntry/src/com/devmarvel/creditcardentry/library/CardType.java
@@ -40,7 +40,7 @@ public enum CardType implements Serializable {
     INVALID("Unknown", R.drawable.unknown_cc, null, null);
 
   /** name for humans */
-    public final String name;
+    public final String friendlyName;
 
   /** regex that matches the entire card number */
     public final String fullRegex;
@@ -54,8 +54,8 @@ public enum CardType implements Serializable {
   /** drawable for the back of the card */
     public final int backResource = R.drawable.cc_back;
 
-    CardType(String name, @DrawableRes int imageResource, String fullRegex, String typeRegex) {
-        this.name = name;
+    CardType(String friendlyName, @DrawableRes int imageResource, String fullRegex, String typeRegex) {
+        this.friendlyName = friendlyName;
         this.frontResource = imageResource;
         this.fullRegex = fullRegex;
         this.typeRegex = typeRegex;
@@ -63,6 +63,6 @@ public enum CardType implements Serializable {
 
     @Override
     public String toString() {
-        return name;
+        return friendlyName;
     }
 }

--- a/CreditCardEntryDemo/build.gradle
+++ b/CreditCardEntryDemo/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
     repositories {
         mavenCentral()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 apply plugin: 'com.android.application'
@@ -13,12 +14,11 @@ repositories {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 25
+        targetSdkVersion 28
     }
 
     sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,18 @@
 buildscript {
     repositories {
         mavenCentral()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 
 repositories {
     mavenCentral()
+    google()
 }
 
 task wrapper(type: Wrapper) {
-        gradleVersion = '2.3.3'
+        gradleVersion = '3.1.4'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jul 16 05:52:41 WAT 2017
+#Wed Sep 05 17:49:40 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
I'm trying to call the following in Kotlin

```
creditCard.cardType.name
```

and I get an error that states 
```
Overload resolution ambiguity, All these functions match.
- public final val name: String! defined in com.devmarvel.creditcardentry.library.CardType
- public final val name: String defined in com.devmarvel.creditcardentry.library.CardType
```

This is an error because Kotlins enum class has a field called `name`, and you cannot override it in the subclass. Renaming `name` to something else fixes the issue.

This PR fixes this issue.
